### PR TITLE
filter data for sparklines by attribute filter (solves #44)

### DIFF
--- a/src/filter_data.ts
+++ b/src/filter_data.ts
@@ -41,7 +41,7 @@ class FilterData implements MAppViews {
     //Add Filters to Pipeline
     this.pipeline.changeTopFilter(this.topFilter); //must be first filter
     this.pipeline.addFilter(this.quarterFilter);
-    this.pipeline.addFilter(this.paragraphFilter);
+    this.pipeline.addAttributeFilter(this.paragraphFilter);
 
     this.$node = d3.select(parent)
       .append('div')

--- a/src/filters/filterpipeline.ts
+++ b/src/filters/filterpipeline.ts
@@ -17,6 +17,8 @@ export default class FilterPipeline
   private _entitySearchFilter: EntitySearchFilter;
   private _mediaSearchFilter: MediaSearchFilter;
 
+  private _attributeFilters = new Array<Filter>();
+
   private constructor()
   {
     this.filters = new Array<Filter>();
@@ -39,6 +41,20 @@ export default class FilterPipeline
     if(newFilter !== null || newFilter !== undefined)
     {
       this.filters.push(newFilter);
+    }
+  }
+
+  /**
+   * add a filter to the pipeline and mark it as an attribute filter.
+   * Sparkline Barcharts are only filtered by attribute filter and nothing else.
+   * @param newFilter
+   */
+  public addAttributeFilter(newFilter: Filter): void
+  {
+    if(newFilter !== null || newFilter !== undefined)
+    {
+      this.filters.push(newFilter);
+      this._attributeFilters.push(newFilter);
     }
   }
 
@@ -75,6 +91,19 @@ export default class FilterPipeline
     for(let filter of this.filters)
     {
         data = filter.meetCriteria(data);
+    }
+    return data;
+  }
+
+  /**
+   * only apply filters marked as attribute filter
+   * @param data
+   */
+  public performAttributeFilters(data: any): any
+  {
+    for(let filter of this._attributeFilters)
+    {
+          data = filter.meetCriteria(data);
     }
     return data;
   }

--- a/src/sparklineBarChart.ts
+++ b/src/sparklineBarChart.ts
@@ -8,6 +8,7 @@ import * as localforage from 'localforage';
 import {AppConstants} from './app_constants';
 import {MAppViews} from './app';
 import {splitAt, dotFormat} from './utilities';
+import FilterPipeline from './filters/filterpipeline';
 
 const CHART_HEIGHT: number = 18;
 const INITIAL_SVG_HEIGHT: number = 100;
@@ -84,14 +85,16 @@ export default class SparklineBarChart implements MAppViews {
         data.map(function (d: any) { return d.timeNode; })
       ).values().sort();
 
+      let attFiltData = FilterPipeline.getInstance().performAttributeFilters(data);
+
       node.each(function (d, i) {
         let nodeElem = d3.select(this);
         let yMiddle = nodeElem.datum().y + nodeElem.datum().dy / 2;
 
         if (nodeElem.attr('class').includes('source')) {
-          SparklineBarChart.sourceChart.build(data, nodeElem.datum().name, yMiddle, timePoints);
+          SparklineBarChart.sourceChart.build(attFiltData, nodeElem.datum().name, yMiddle, timePoints);
         } else {
-          SparklineBarChart.targetChart.build(data, nodeElem.datum().name, yMiddle, timePoints);
+          SparklineBarChart.targetChart.build(attFiltData, nodeElem.datum().name, yMiddle, timePoints);
         }
       });
     });


### PR DESCRIPTION
Currently the only attribute filter is paragraph filter.

Implementation: The singleton FilterPipeLines keeps a separate record of attribute filters.